### PR TITLE
Fixes an issue where docker-compose always fails to install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ VENDOR_DIR=$BUILD_DIR/vendor
 mkdir -p $CACHE_DIR $VENDOR_DIR
 
 DOCKER_VERSION=`curl -s https://download.docker.com/linux/static/stable/x86_64/ | grep "\-ce" | grep -oP "[0-9]+\.[0-9]+\.[0-9]" | tail -n 1`
-COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | tail -n 1`
+COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep -oP 'refs/tags/[0-9]+\.[0-9][0-9]+\.[0-9]+$' | cut -c 11- | tail -n 1`
 
 LOCAL_DOCKER_TGZ=$CACHE_DIR/docker-$DOCKER_VERSION.tgz
 LOCAL_COMPOSE=$CACHE_DIR/docker-compose-$COMPOSE_VERSION


### PR DESCRIPTION
The docker-compose repo recently published a release tagged with v1.25.2 (on the 20 Jan 2020).

Since this time it hasn't been possible to install the docker-compose command on heroku using this buildpack. This is caused by the `v` prefix not being taken into account in the version detection part of the compile script.

For example, running
```
git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$"
```
results in the most recents versions being
```
1.25.3
1.25.4
1.25.2
```

Version `1.25.2` is always last in this list because the tags are actually as follows before the regex extracts just the numbers.
```
1.25.3
1.25.4
v1.25.2
```

The first issue here is this means that version `v1.25.2` is always considered the most recent version. The second issue comes when trying to download the compose binary since it resolves to the incorrect URL because the version prefix has been removed.

I have updated the regex to look specifically for `refs/tags/` followed by a decimal version number. This means the script will skip over any versions prefixed with a non-numeric character.